### PR TITLE
Change to relative imports

### DIFF
--- a/cquery/__init__.py
+++ b/cquery/__init__.py
@@ -1,2 +1,2 @@
-from cquery.lib import *
-from cquery.version import *
+from .lib import *
+from .version import *

--- a/cquery/__main__.py
+++ b/cquery/__main__.py
@@ -4,7 +4,7 @@ This module makes the cQuery package into an executable, via cli.py
 
 """
 
-import cquery.cli
+from . import cli
 
 
 def main():


### PR DESCRIPTION
Changes imports of `cquery` to relative imports.

This allows the package to be embedded in other packages, like under `vendors` or alike.
